### PR TITLE
Include installation steps for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,9 @@ $ source ~/.zshrc
 $ rbenv install 3.2.3
 ```
 
+#### Windows
+Follow steps to install ruby version 3.2.3 on your system. You can use a package manager like rbenv.
+
 ### Setup Project
 
 Clone the repo and install dependencies:


### PR DESCRIPTION
https://tiugotech.atlassian.net/browse/BCMS-769
Missing Windows installation instructions in prerequisites section
The current Prerequisites section in README provides setup instructions only for Ubuntu and macOS. However, there's no guidance for developers on Windows, which may hinder onboarding for a large segment of users.

For Hugo starter there is not Prerequisites section and the requirements are listed directly in Installation section, but the instructions for Windows are similarly missing.